### PR TITLE
Variables in the configuration file are set as environment variables in the shell that execute the command

### DIFF
--- a/.sam_rc.toml
+++ b/.sam_rc.toml
@@ -1,1 +1,3 @@
 root_dir="./examples/oneliners"
+
+variable="toto"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,9 +925,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "skim"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141d16fb63a98e3ed0e4012546074967bffbdb94dc251f00f497b5343ad4beb5"
+checksum = "1ac8dcb2f57eba70ce16c6844af6caa63dc642d404630aae5dc3b4cb48353962"
 dependencies = [
  "beef",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.117",
+ "serde",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits",
  "time",
  "winapi",
 ]
@@ -138,22 +138,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static",
- "nom",
- "rust-ini",
- "serde 1.0.117",
- "serde-hjson",
- "serde_json",
- "toml",
- "yaml-rust",
 ]
 
 [[package]]
@@ -321,7 +305,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.117",
+ "serde",
 ]
 
 [[package]]
@@ -544,33 +528,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 0.1.10",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
-dependencies = [
- "serde 0.8.23",
- "serde_test",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -628,33 +589,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg",
- "num-traits 0.2.12",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.12",
+ "num-traits",
 ]
 
 [[package]]
@@ -910,12 +851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-ini"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,7 +861,6 @@ name = "sam"
 version = "0.9.0"
 dependencies = [
  "clap",
- "config",
  "crossbeam 0.8.0",
  "crossbeam-channel 0.5.0",
  "dirs 3.0.1",
@@ -935,12 +869,13 @@ dependencies = [
  "prettytable-rs",
  "rand 0.7.3",
  "regex",
- "serde 1.0.117",
+ "serde",
  "serde_yaml",
  "skim",
  "tempdir",
  "termion",
  "thiserror",
+ "toml",
  "uuid",
 ]
 
@@ -952,30 +887,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static",
- "linked-hash-map 0.3.0",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
 ]
 
 [[package]]
@@ -990,34 +906,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
-dependencies = [
- "itoa",
- "ryu",
- "serde 1.0.117",
-]
-
-[[package]]
-name = "serde_test"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
-dependencies = [
- "serde 0.8.23",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
- "linked-hash-map 0.5.3",
- "serde 1.0.117",
+ "linked-hash-map",
+ "serde",
  "yaml-rust",
 ]
 
@@ -1054,12 +950,6 @@ dependencies = [
  "unicode-width",
  "vte",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1196,11 +1086,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde 1.0.117",
+ "serde",
 ]
 
 [[package]]
@@ -1242,7 +1132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "rand 0.7.3",
- "serde 1.0.117",
+ "serde",
 ]
 
 [[package]]
@@ -1250,12 +1140,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"
@@ -1321,5 +1205,5 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
- "linked-hash-map 0.5.3",
+ "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ assets = [
 serde = { version = "1.0", features = ["derive"] }
 clap = "2.33"
 serde_yaml = "0.8"
-config = "0.10.1"
 skim = "0.9.1"
 dirs = "3.0.1"
 crossbeam = "0.8.0"
@@ -45,6 +44,7 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 prettytable-rs = "0.8.0"
 termion = "1.0.0"
 thiserror = "1.0.22"
+toml = "0.4.2"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ assets = [
 serde = { version = "1.0", features = ["derive"] }
 clap = "2.33"
 serde_yaml = "0.8"
-skim = "0.9.1"
+skim = "0.9.3"
 dirs = "3.0.1"
 crossbeam = "0.8.0"
 crossbeam-channel = "0.5.0"

--- a/examples/oneliners/aliases.yaml
+++ b/examples/oneliners/aliases.yaml
@@ -6,5 +6,8 @@
   desc: prints home directory
   alias: echo $HOME
 
+- name: echo_env_var
+  desc: prints a variable defined in the configuration
+  alias: echo $variable
 
 

--- a/src/bin/sam/config.rs
+++ b/src/bin/sam/config.rs
@@ -6,7 +6,6 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-use toml::Value;
 
 const CONFIG_FILE_NAME: &str = ".sam_rc.toml";
 
@@ -14,7 +13,7 @@ const CONFIG_FILE_NAME: &str = ".sam_rc.toml";
 pub struct AppSettings {
     root_dir: PathBuf,
     #[serde(flatten)]
-    variables: HashMap<String, Value>,
+    variables: HashMap<String, String>,
 }
 
 type Result<T> = std::result::Result<T, ErrorsConfig>;
@@ -63,6 +62,9 @@ impl AppSettings {
         std::env::current_dir()
             .map_err(|_| ErrorsConfig::CantFindCurrentDirectory)
             .map(|e| e.join(CONFIG_FILE_NAME))
+    }
+    pub fn variables(&self) -> HashMap<String, String> {
+        self.variables.clone()
     }
 }
 

--- a/src/bin/sam/main.rs
+++ b/src/bin/sam/main.rs
@@ -88,6 +88,7 @@ struct AppContext {
 impl AppContext {
     fn try_load(dry: bool, silent: bool) -> Result<AppContext> {
         let config = AppSettings::load()?;
+        println!("{:?}", config);
         let ui_interface = userinterface::UserInterface::new(silent)?;
         let files = walk_dir(config.root_dir())?;
         let mut aliases = vec![];

--- a/src/bin/sam/userinterface.rs
+++ b/src/bin/sam/userinterface.rs
@@ -23,10 +23,14 @@ pub struct UserInterface {
     chosen_alias: Option<Alias>,
     choices: RefCell<HashMap<Identifier, Choice>>,
     silent: bool,
+    variables: HashMap<String, String>,
 }
 
 impl UserInterface {
-    pub fn new(silent: bool) -> Result<UserInterface, ErrorsUI> {
+    pub fn new(
+        silent: bool,
+        variables: HashMap<String, String>,
+    ) -> Result<UserInterface, ErrorsUI> {
         let preview_file = TempFile::new()?;
         let preview_command = format!("cat {}", &preview_file.path.as_path().display());
         Ok(UserInterface {
@@ -35,6 +39,7 @@ impl UserInterface {
             chosen_alias: None,
             choices: RefCell::new(HashMap::new()),
             silent,
+            variables,
         })
     }
 
@@ -270,6 +275,7 @@ impl Resolver for UserInterface {
         }
 
         let mut to_run = ShellCommand::as_command(sh_cmd.clone());
+        to_run.envs(&self.variables);
         let output = to_run
             .output()
             .map_err(|e| ErrorsResolver::DynamicResolveFailure(var.clone(), e.into()))?;


### PR DESCRIPTION
This features allows you to keep workstation specific information ( credentials, paths etc...) out of your vars and aliases definitions. It will ease reuse. 