### PR TITLE
feat(sam-persistence): remove rocksdb dependency for caching and history

### DIFF
--- a/.sam/project/aliases.yml
+++ b/.sam/project/aliases.yml
@@ -18,3 +18,11 @@
 - name: delete_merged_branches
   desc: delete all the local branches that have been merged
   alias: git branch --merged | egrep -v "(^\*|master|main|dev)" | xargs git branch -d
+
+- name: list_unused_dependencies
+  desc: uses cargo udep to list unused dependencies
+  alias: cargo +nightly udeps --all-targets
+
+- name: list_outdated_dependencies
+  desc: uses cargo outdated to list the outdated dependencies of the workspace
+  alias: cargo outdated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,56 +50,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "beef"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 1.0.0",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bumpalo"
@@ -112,18 +78,6 @@ name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
-dependencies = [
- "jobserver",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -148,17 +102,6 @@ dependencies = [
  "num-traits",
  "time 0.1.43",
  "winapi",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -415,12 +358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,12 +376,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
@@ -485,18 +416,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lazy_static"
@@ -505,38 +427,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
-
-[[package]]
-name = "libloading"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
-dependencies = [
- "cfg-if 1.0.0",
- "winapi",
-]
-
-[[package]]
-name = "librocksdb-sys"
-version = "6.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
-dependencies = [
- "bindgen",
- "cc",
- "glob",
- "libc",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -606,18 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec",
- "funty",
- "memchr",
- "version_check",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,12 +541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,12 +569,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -811,20 +681,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "rocksdb"
-version = "0.17.0"
+name = "remove_dir_all"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "libc",
- "librocksdb-sys",
+ "winapi",
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
+name = "ron"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
+name = "rustbreak"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460d97902465327d69ecfe8cefdb5972c6f94d6127ac9e992acdb51458bebc27"
+dependencies = [
+ "ron",
+ "serde",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "rustc_version"
@@ -878,15 +764,13 @@ dependencies = [
 name = "sam-persistence"
 version = "0.17.2"
 dependencies = [
- "bincode",
  "lazy_static",
  "maplit",
  "regex",
- "rocksdb",
+ "rustbreak",
  "sam-core",
  "sam-utils",
  "serde",
- "serde_yaml",
  "thiserror",
 ]
 
@@ -967,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
  "itoa",
  "ryu",
@@ -1011,12 +895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
-name = "shlex"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
-
-[[package]]
 name = "skim"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,7 +915,7 @@ dependencies = [
  "nix 0.19.1",
  "rayon",
  "regex",
- "shlex 0.1.1",
+ "shlex",
  "time 0.2.27",
  "timer",
  "tuikit",
@@ -1127,10 +1005,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
+name = "tempfile"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "term"
@@ -1438,12 +1324,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-rust"

--- a/sam-cli/src/cache_engine.rs
+++ b/sam-cli/src/cache_engine.rs
@@ -1,4 +1,4 @@
-use sam_persistence::{CacheError, RocksDBCache};
+use sam_persistence::{CacheError, RustBreakCache};
 use std::path::PathBuf;
 use std::time::Duration;
 use thiserror::Error;
@@ -23,19 +23,19 @@ impl CacheEngine {
     }
 
     fn print_keys(self) -> Result<i32> {
-        let cache = RocksDBCache::with_ttl(self.cache_dir, &self.ttl);
+        let cache = RustBreakCache::with_ttl(self.cache_dir, &self.ttl)?;
         println!(
             "{}{}Keys present in cache{}\n",
             termion::style::Bold,
             termion::color::Fg(termion::color::Green),
             termion::style::Reset,
         );
-        for key in cache.keys()? {
+        for key in cache.entries()? {
             println!(
                 "- {}{}{}{}",
                 termion::style::Bold,
                 termion::color::Fg(termion::color::Green),
-                key,
+                key.command,
                 termion::style::Reset,
             );
         }
@@ -43,7 +43,7 @@ impl CacheEngine {
     }
 
     fn cache_clear(self) -> Result<i32> {
-        Ok(RocksDBCache::with_ttl(self.cache_dir, &self.ttl)
+        Ok(RustBreakCache::with_ttl(self.cache_dir, &self.ttl)?
             .clear_cache()
             .map(|_| 0)?)
     }

--- a/sam-cli/src/config.rs
+++ b/sam-cli/src/config.rs
@@ -24,7 +24,7 @@ pub struct AppSettings {
     #[serde(skip)]
     cache_dir: PathBuf,
     #[serde(skip)]
-    history_dir: PathBuf,
+    history_file: PathBuf,
     #[serde(skip)]
     pub dry: bool,
     #[serde(skip)]
@@ -55,14 +55,14 @@ impl AppSettings {
         let config_current_dir = current_dir_o.and_then(Self::read_config);
 
         let cache_dir = Self::cache_dir_path()?;
-        let history_dir = Self::history_dir_path()?;
+        let history_file = Self::history_file_path()?;
 
         let mut settings = config_current_dir
             .or(config_home_dir)
             .and_then(AppSettings::validate)
             .map(|mut e| {
                 e.cache_dir = cache_dir;
-                e.history_dir = history_dir;
+                e.history_file = history_file;
                 e
             })?;
 
@@ -88,8 +88,8 @@ impl AppSettings {
         self.cache_dir.as_ref()
     }
 
-    pub fn history_dir(&self) -> &'_ Path {
-        self.history_dir.as_ref()
+    pub fn history_file(&self) -> &'_ Path {
+        self.history_file.as_ref()
     }
 
     fn validate(orig: AppSettings) -> Result<AppSettings> {
@@ -115,9 +115,9 @@ impl AppSettings {
             .ok_or(ErrorsSettings::CantFindCacheDirectory)
     }
 
-    fn history_dir_path() -> Result<PathBuf> {
+    fn history_file_path() -> Result<PathBuf> {
         dirs::home_dir()
-            .map(|e| e.join(".local").join("share").join("sam"))
+            .map(|e| e.join(".local").join("share").join("sam").join("history"))
             .ok_or(ErrorsSettings::CantFindCacheDirectory)
     }
 

--- a/sam-core/src/engines/mocks.rs
+++ b/sam-core/src/engines/mocks.rs
@@ -34,7 +34,7 @@ pub struct InMemoryHistory {
 }
 
 impl SamHistory for InMemoryHistory {
-    fn put(&self, alias: ResolvedAlias) -> Result<(), ErrorSamEngine> {
+    fn put(&mut self, alias: ResolvedAlias) -> Result<(), ErrorSamEngine> {
         let mut queue = self.aliases.borrow_mut();
         queue.push_front(alias);
         Ok(())

--- a/sam-core/src/entities/aliases.rs
+++ b/sam-core/src/entities/aliases.rs
@@ -66,7 +66,7 @@ impl Alias {
         Ok(ResolvedAlias {
             name: self.name.clone(),
             desc: self.desc.clone(),
-            orignal_alias: self.alias.clone(),
+            original_alias: self.alias.clone(),
             resolved_alias: res,
             choices: choices.clone(),
         })
@@ -144,12 +144,27 @@ impl Dependencies for Alias {}
 pub struct ResolvedAlias {
     name: Identifier,
     desc: String,
-    orignal_alias: String,
+    original_alias: String,
     resolved_alias: String,
     choices: HashMap<Identifier, Choice>,
 }
 
 impl ResolvedAlias {
+    pub fn new(
+        name: Identifier,
+        desc: String,
+        original_alias: String,
+        resolved_alias: String,
+        choices: HashMap<Identifier, Choice>,
+    ) -> Self {
+        ResolvedAlias {
+            name,
+            desc,
+            original_alias,
+            resolved_alias,
+            choices,
+        }
+    }
     pub fn choice(&self, identifier: &Identifier) -> Option<Choice> {
         self.choices.get(identifier).map(Clone::clone)
     }
@@ -158,8 +173,18 @@ impl ResolvedAlias {
         &self.name
     }
 
+    pub fn desc(&self) -> &str {
+        &self.desc
+    }
+
     pub fn choices(&self) -> &HashMap<Identifier, Choice> {
         &self.choices
+    }
+    pub fn original_alias(&self) -> &str {
+        &self.original_alias
+    }
+    pub fn resolved_alias(&self) -> &str {
+        &self.resolved_alias
     }
 }
 
@@ -168,7 +193,7 @@ impl From<ResolvedAlias> for Alias {
         Alias {
             name: r_alias.name,
             desc: r_alias.desc,
-            alias: r_alias.orignal_alias,
+            alias: r_alias.original_alias,
         }
     }
 }

--- a/sam-persistence/Cargo.toml
+++ b/sam-persistence/Cargo.toml
@@ -8,12 +8,10 @@ edition = "2021"
 [dependencies]
 sam-utils = {path="../sam-utils"}
 sam-core = {path="../sam-core"}
-rocksdb = "0.17.0"
 thiserror = "1.0.30"
 serde = { version = "1.0.130", features = ["derive"] }
-bincode = "1.3.3"
-serde_yaml = "0.8.21"
 lazy_static = "1.4.0"
+rustbreak = { version = "2.0.0", features = ["ron_enc"] }
 regex = "1.5.4"
 maplit = "1.0.2"
 

--- a/sam-persistence/src/associative_state.rs
+++ b/sam-persistence/src/associative_state.rs
@@ -1,0 +1,275 @@
+use rustbreak::RustbreakError;
+use rustbreak::{deser::Ron, FileDatabase};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct AssociativeStateWithTTL<V> {
+    path: PathBuf,
+    ttl: Option<Duration>,
+    _marker: PhantomData<V>,
+}
+
+#[derive(Error, Debug)]
+pub enum ErrorAssociativeState {
+    #[error("failed to create associative state because\n->{0}")]
+    CreationFailure(RustbreakError),
+    #[error("failed to initialize associative state because\n->{0}")]
+    InitFailure(RustbreakError),
+    #[error("failed to load associative state because\n->{0}")]
+    OpenFailure(RustbreakError),
+    #[error("failed to write to associative state because\n->{0}")]
+    WriteFailures(RustbreakError),
+    #[error("failed to save to associative state because\n->{0}")]
+    SaveFailures(RustbreakError),
+    #[error("failed to read from associative state because\n->{0}")]
+    ReadFailure(RustbreakError),
+}
+
+pub trait Value: Serialize + DeserializeOwned + Send + Clone + std::fmt::Debug {}
+impl<T> Value for T where T: Serialize + DeserializeOwned + Send + Clone + std::fmt::Debug {}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+struct StateEntry<V> {
+    entry: V,
+    when: u64,
+}
+
+impl<V> StateEntry<V> {
+    pub fn new(value: V) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("can't get system time");
+        StateEntry {
+            entry: value,
+            when: now.as_secs(),
+        }
+    }
+}
+
+type FDB<V> = FileDatabase<HashMap<String, StateEntry<V>>, Ron>;
+
+impl<V> AssociativeStateWithTTL<V>
+where
+    V: Value,
+{
+    pub fn with_ttl(p: impl AsRef<Path>, ttl: &Duration) -> Result<Self, ErrorAssociativeState> {
+        let db = AssociativeStateWithTTL {
+            path: p.as_ref().to_owned(),
+            ttl: Some(*ttl),
+            _marker: PhantomData::default(),
+        };
+        db.open_db()?;
+        Ok(db)
+    }
+
+    pub fn new(p: impl AsRef<Path>) -> Result<Self, ErrorAssociativeState> {
+        let db = AssociativeStateWithTTL {
+            path: p.as_ref().to_owned(),
+            ttl: None,
+            _marker: PhantomData::default(),
+        };
+        db.open_db()?;
+        Ok(db)
+    }
+
+    pub fn put(&self, key: impl AsRef<str>, value: V) -> Result<(), ErrorAssociativeState> {
+        let db = self.open_db()?;
+        let entry = StateEntry::new(value);
+        db.write(|db| {
+            db.insert(key.as_ref().to_string(), entry);
+
+            let mut keys_to_drop = vec![];
+            for (key, value) in db.iter() {
+                if !self.is_value_valid(value) {
+                    keys_to_drop.push(key.clone());
+                }
+            }
+
+            for key in keys_to_drop {
+                db.remove(&key);
+            }
+        })
+        .map_err(ErrorAssociativeState::WriteFailures)?;
+        db.save().map_err(ErrorAssociativeState::SaveFailures)
+    }
+
+    pub fn get(&self, command: impl AsRef<str>) -> Result<Option<V>, ErrorAssociativeState> {
+        let db = self.open_db()?;
+        let cache_key = command.as_ref();
+        let entry = db
+            .read(|db| db.get(cache_key).map(Clone::clone))
+            .map_err(ErrorAssociativeState::ReadFailure)?;
+        Ok(entry.filter(|v| self.is_value_valid(v)).map(|e| e.entry))
+    }
+
+    pub fn delete(&self, key: impl AsRef<str>) -> Result<Option<V>, ErrorAssociativeState> {
+        let db = self.open_db()?;
+        let cache_key = key.as_ref();
+        let entry = db
+            .write(|db| db.remove(cache_key))
+            .map_err(ErrorAssociativeState::WriteFailures)?;
+        db.save().map_err(ErrorAssociativeState::SaveFailures)?;
+        Ok(entry.filter(|v| self.is_value_valid(v)).map(|e| e.entry))
+    }
+
+    pub fn entries(&self) -> Result<impl Iterator<Item = (String, V)>, ErrorAssociativeState> {
+        let db = self.open_db()?;
+        db.read(|db| db.clone().into_iter().map(|(k, v)| (k, v.entry)))
+            .map_err(ErrorAssociativeState::ReadFailure)
+    }
+
+    fn open_db(&self) -> Result<FDB<V>, ErrorAssociativeState> {
+        Ok(FDB::<V>::load_from_path(&self.path)
+            .or(FDB::<V>::create_at_path(&self.path, HashMap::default()))
+            .map_err(ErrorAssociativeState::OpenFailure)?)
+    }
+    fn is_value_valid(&self, c: &StateEntry<V>) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Can't get system time");
+        if let Some(ttl) = self.ttl.as_ref() {
+            c.when + ttl.as_secs() > now.as_secs()
+        } else {
+            true
+        }
+    }
+}
+
+pub trait EntrySelector<V> {
+    fn select_entry(
+        &self,
+        data: impl Iterator<Item = (String, V)>,
+    ) -> Result<Option<String>, Box<dyn std::error::Error>>;
+}
+
+pub trait EntryUpdater<V> {
+    fn update_value(&self, key: &str, value: &V) -> Result<Option<V>, Box<dyn std::error::Error>>;
+}
+
+pub struct AssociativeStateInteractor<V, D> {
+    state: AssociativeStateWithTTL<V>,
+    delegate: D,
+}
+
+impl<V, D> AssociativeStateInteractor<V, D> {
+    fn new(path: impl AsRef<Path>, ttl: Option<Duration>, delegate: D) -> Self {
+        AssociativeStateInteractor {
+            state: AssociativeStateWithTTL {
+                path: path.as_ref().to_path_buf(),
+                ttl,
+                _marker: PhantomData::default(),
+            },
+            delegate,
+        }
+    }
+}
+
+impl<V, D> AssociativeStateInteractor<V, D>
+where
+    D: EntrySelector<V>,
+    V: Value,
+{
+    fn delete_entry(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let state_iterator = self.entries()?;
+        let selected_element = self.delegate.select_entry(state_iterator)?;
+        if let Some(key) = selected_element {
+            self.state.delete(key)?;
+        }
+        Ok(())
+    }
+}
+
+impl<V, D> AssociativeStateInteractor<V, D>
+where
+    D: EntrySelector<V> + EntryUpdater<V>,
+    V: Value,
+{
+    fn update_entry(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let state_iterator = self.entries()?;
+        let selected_key = self.delegate.select_entry(state_iterator)?;
+        let selected_value = selected_key
+            .as_deref()
+            .and_then(|k| self.state.get(k).transpose())
+            .transpose()?;
+        if let Some((k, v)) = selected_key.zip(selected_value) {
+            let updated_value = self.delegate.update_value(&k, &v)?;
+            updated_value.map(|v| self.state.put(k, v));
+        }
+        Ok(())
+    }
+}
+
+impl<V, D> AssociativeStateInteractor<V, D>
+where
+    V: Value,
+{
+    fn entries(&self) -> Result<impl Iterator<Item = (String, V)>, ErrorAssociativeState> {
+        self.state.entries()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sam_utils::fsutils::TempFile;
+
+    use super::{AssociativeStateWithTTL, Value};
+
+    fn make_temp_state<V: Value>() -> AssociativeStateWithTTL<V> {
+        let f = TempFile::new().expect("failed to created a temporary file");
+        AssociativeStateWithTTL::new(f.path).expect("failed to create a new db")
+    }
+
+    #[test]
+    fn test_associative_state() {
+        let db = make_temp_state::<i32>();
+        let values = vec![
+            (String::from("str"), 1),
+            (String::from("str_1"), 2),
+            (String::from("str_2"), 3),
+        ];
+
+        for (k, v) in &values {
+            db.put(k, *v).expect("could not put");
+        }
+
+        let entries: Vec<(String, i32)> = db.entries().expect("can't get entries").collect();
+        assert_eq!(entries.clone().sort(), values.clone().sort());
+
+        let value = db
+            .get(String::from("str"))
+            .expect("can't get data from state")
+            .expect("Got a None when I expected a value");
+
+        assert_eq!(value, 1);
+
+        let value2 = db
+            .delete(String::from("str"))
+            .expect("can't get data from state")
+            .expect("Got a None when I expected a value");
+
+        assert_eq!(value2, 1);
+        assert!(db
+            .get(String::from("str"))
+            .expect("can't get data from state")
+            .is_none());
+    }
+
+    #[test]
+    fn test_associative_state_interactor_delete_entry() {}
+
+    #[test]
+    fn test_associative_state_interactor_update_entry() {}
+
+    #[test]
+    fn test_associative_state_interactor_entries() {}
+}

--- a/sam-persistence/src/history_aliases.rs
+++ b/sam-persistence/src/history_aliases.rs
@@ -1,0 +1,100 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use thiserror::Error;
+
+use sam_core::{
+    engines::{ErrorSamEngine, SamHistory},
+    entities::aliases::ResolvedAlias,
+};
+
+use crate::sequential_state::{ErrorSequentialState, SequentialState};
+
+#[derive()]
+pub struct AliasHistory {
+    state: SequentialState<HistoryEntry>,
+    pwd: PathBuf,
+}
+
+#[derive(Debug, Error)]
+pub enum ErrorAliasHistory {
+    #[error("failed to interact with alias history\n->{0}")]
+    ErrSequentialState(#[from] ErrorSequentialState),
+}
+
+impl AliasHistory {
+    pub fn new(
+        path: impl Into<PathBuf>,
+        max_size: Option<usize>,
+    ) -> Result<Self, ErrorAliasHistory> {
+        let state = SequentialState::new(path.into(), max_size)?;
+        let pwd = std::env::current_dir().expect("can't figure out local directory");
+        Ok(AliasHistory { state, pwd })
+    }
+}
+
+impl SamHistory for AliasHistory {
+    fn put(&mut self, alias: ResolvedAlias) -> Result<(), ErrorSamEngine> {
+        let entry = HistoryEntry {
+            r: alias,
+            pwd: self.pwd.to_string_lossy().to_string(),
+        };
+        self.state
+            .push(entry)
+            .map_err(|err| ErrorSamEngine::HistoryNotAvailable(Box::new(err)))
+    }
+
+    fn get_last_n(&self, n: usize) -> Result<Vec<ResolvedAlias>, ErrorSamEngine> {
+        let entries = self
+            .state
+            .entries()
+            .map_err(|err| ErrorSamEngine::HistoryNotAvailable(Box::new(err)))?;
+        let entries_vec: Vec<ResolvedAlias> = entries.map(|e| e.r).collect();
+        if entries_vec.len() > n {
+            let skip = entries_vec.len() - n;
+            Ok(entries_vec.into_iter().skip(skip).collect())
+        } else {
+            Ok(entries_vec)
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct HistoryEntry {
+    r: ResolvedAlias,
+    pwd: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use sam_core::{
+        engines::SamHistory,
+        entities::{aliases::ResolvedAlias, choices::Choice, identifiers::Identifier},
+    };
+    use sam_utils::fsutils;
+
+    use super::AliasHistory;
+
+    #[test]
+    fn test_history_put() {
+        let f = fsutils::TempFile::new().expect("can't create temp file for test");
+        let mut hist = AliasHistory::new(f.path, None).expect("can't create history file");
+        let test = ResolvedAlias::new(
+            Identifier::with_namespace("alias", Some("ns")),
+            String::from("desc"),
+            String::from("echo {{var}}"),
+            String::from("echo choice"),
+            maplit::hashmap! {
+                Identifier::new("var") => Choice::new("choice", None),
+            },
+        );
+        hist.put(test.clone()).expect("The put should succeed");
+        let last = hist
+            .get_last()
+            .expect("should be able to read")
+            .expect("Expecting a value to be returned");
+        assert_eq!(test, last);
+    }
+
+    #[test]
+    fn test_history_get_last_n() {}
+}

--- a/sam-persistence/src/lib.rs
+++ b/sam-persistence/src/lib.rs
@@ -1,7 +1,11 @@
+mod associative_state;
+mod history_aliases;
 pub mod repositories;
+mod sequential_state;
 mod vars_cache;
-pub use vars_cache::CacheEntry;
+pub use history_aliases::AliasHistory;
+pub use history_aliases::ErrorAliasHistory;
 pub use vars_cache::CacheError;
 pub use vars_cache::NoopVarsCache;
-pub use vars_cache::RocksDBCache;
+pub use vars_cache::RustBreakCache;
 pub use vars_cache::VarsCache;

--- a/sam-persistence/src/sequential_state.rs
+++ b/sam-persistence/src/sequential_state.rs
@@ -1,0 +1,213 @@
+use rustbreak::deser::Ron;
+use rustbreak::FileDatabase;
+use rustbreak::RustbreakError;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::path::PathBuf;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct SequentialState<V> {
+    path: PathBuf,
+    max_size: Option<usize>,
+    _marker: PhantomData<V>,
+}
+
+#[derive(Error, Debug)]
+pub enum ErrorSequentialState {
+    #[error("failed to create sequential state because\n->{0}")]
+    CreationFailure(RustbreakError),
+    #[error("failed to initialize sequential state because\n->{0}")]
+    InitFailure(RustbreakError),
+    #[error("failed to load sequential state because\n->{0}")]
+    OpenFailure(RustbreakError),
+    #[error("failed to write to sequential state because\n->{0}")]
+    WriteFailures(RustbreakError),
+    #[error("failed to save to sequential state because\n->{0}")]
+    SaveFailures(RustbreakError),
+    #[error("failed to read from sequential state because\n->{0}")]
+    ReadFailure(RustbreakError),
+}
+
+pub type ModResult<V> = std::result::Result<V, ErrorSequentialState>;
+
+type FDB<V> = FileDatabase<Vec<V>, Ron>;
+
+pub trait Value: Serialize + DeserializeOwned + Send + Clone + std::fmt::Debug {}
+impl<T> Value for T where T: Serialize + DeserializeOwned + Send + Clone + std::fmt::Debug {}
+
+impl<V> SequentialState<V>
+where
+    V: Value,
+{
+    pub fn new(p: impl AsRef<Path>, max_size: Option<usize>) -> ModResult<Self> {
+        let db = SequentialState {
+            path: p.as_ref().to_owned(),
+            max_size,
+            _marker: PhantomData::default(),
+        };
+        db.open_db()?;
+        Ok(db)
+    }
+
+    pub fn push(&self, entry: V) -> ModResult<()> {
+        let db = self.open_db()?;
+        db.write(|db| {
+            db.push(entry);
+            if let Some(max_size) = self.max_size {
+                if db.len() > max_size {
+                    db.remove(0);
+                }
+            }
+        })
+        .map_err(ErrorSequentialState::WriteFailures)?;
+        db.save().map_err(ErrorSequentialState::SaveFailures)
+    }
+
+    pub fn last(&self) -> ModResult<Option<V>> {
+        let db = self.open_db()?;
+        db.read(|db| db.last().map(Clone::clone))
+            .map_err(ErrorSequentialState::ReadFailure)
+    }
+
+    pub fn first(&self) -> ModResult<Option<V>> {
+        let db = self.open_db()?;
+        db.read(|db| db.first().map(Clone::clone))
+            .map_err(ErrorSequentialState::ReadFailure)
+    }
+
+    pub fn entries(&self) -> ModResult<impl Iterator<Item = V>> {
+        let db = self.open_db()?;
+        db.read(|db| db.clone().into_iter())
+            .map_err(ErrorSequentialState::ReadFailure)
+    }
+
+    pub fn delete(&self, position: usize) -> ModResult<()> {
+        let db = self.open_db()?;
+        db.write(|db| {
+            db.remove(position);
+        })
+        .map_err(ErrorSequentialState::WriteFailures)?;
+        db.save().map_err(ErrorSequentialState::SaveFailures)
+    }
+
+    fn open_db(&self) -> ModResult<FDB<V>> {
+        Ok(FDB::<V>::load_from_path(&self.path)
+            .or(FDB::<V>::create_at_path(&self.path, vec![]))
+            .map_err(ErrorSequentialState::OpenFailure)?)
+    }
+}
+
+pub trait EntrySelector<V> {
+    fn select_entry(
+        &self,
+        data: impl Iterator<Item = (usize, V)>,
+    ) -> Result<Option<usize>, Box<dyn std::error::Error>>;
+}
+
+#[derive(Debug, Error)]
+pub enum ErrorSeqStateInteractor {
+    #[error("failed to interract with state because \n->{0}")]
+    ErrState(#[from] ErrorSequentialState),
+    #[error("failed to select entry because\n->{0}")]
+    ErrEntrySelector(Box<dyn std::error::Error>),
+}
+
+pub struct SequentialStateInteractor<V, D> {
+    state: SequentialState<V>,
+    delegate: D,
+}
+
+impl<V, D> SequentialStateInteractor<V, D> {
+    fn new(path: impl AsRef<Path>, delegate: D, max_size: Option<usize>) -> Self {
+        SequentialStateInteractor {
+            state: SequentialState {
+                path: path.as_ref().to_path_buf(),
+                _marker: PhantomData::default(),
+                max_size,
+            },
+            delegate,
+        }
+    }
+}
+
+impl<V, D> SequentialStateInteractor<V, D>
+where
+    D: EntrySelector<V>,
+    V: Value,
+{
+    fn delete_entry(&self) -> Result<(), ErrorSeqStateInteractor> {
+        let state_iterator = self.entries()?;
+        let selected_element = self
+            .delegate
+            .select_entry(state_iterator)
+            .map_err(ErrorSeqStateInteractor::ErrEntrySelector)?;
+        if let Some(position) = selected_element {
+            self.state.delete(position)?;
+        }
+        Ok(())
+    }
+}
+impl<V, D> SequentialStateInteractor<V, D>
+where
+    V: Value,
+{
+    fn entries(&self) -> Result<impl Iterator<Item = (usize, V)>, ErrorSeqStateInteractor> {
+        Ok(self.state.entries()?.enumerate())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sam_utils::fsutils::TempFile;
+
+    use super::{ModResult, SequentialState, Value};
+
+    fn make_temp_state<V: Value>() -> SequentialState<V> {
+        let f = TempFile::new().expect("failed to created a temporary file");
+        SequentialState::new(f.path, None).expect("failed to create a new db")
+    }
+
+    fn insert_values<V: Value>(state: &SequentialState<V>, values: &[V]) -> ModResult<()> {
+        for v in values {
+            state.push(v.clone())?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_sequential_state() {
+        let values = vec![1, 2, 3, 4, 7];
+        let state = make_temp_state::<i32>();
+        insert_values(&state, &values).expect("could not into state");
+        let returned_values: Vec<i32> =
+            state.entries().expect("call to into_iter failed").collect();
+        assert_eq!(returned_values, values);
+
+        state.delete(1).expect("could not delete from state");
+
+        let values = vec![1, 3, 4, 7];
+        let returned_values: Vec<i32> =
+            state.entries().expect("call to into_iter failed").collect();
+        assert_eq!(returned_values, values);
+    }
+
+    #[test]
+    fn test_sequential_state_first_last() {
+        let values = vec![1, 2, 3, 4, 7];
+        let state = make_temp_state::<i32>();
+        insert_values(&state, &values).expect("could not into state");
+
+        assert_eq!(state.first().expect("could not get first element"), Some(1));
+        assert_eq!(state.last().expect("could not get last element"), Some(7));
+    }
+
+    #[test]
+    fn test_sequential_state_interactor_entries() {}
+
+    #[test]
+    fn test_sequential_state_interactor_delete_entry() {}
+}

--- a/sam-persistence/src/vars_cache.rs
+++ b/sam-persistence/src/vars_cache.rs
@@ -1,21 +1,62 @@
-use rocksdb::WriteBatch;
-use rocksdb::WriteOptions;
-use rocksdb::DB;
-use sam_core::engines::ErrorSamEngine;
-use sam_core::entities::aliases::ResolvedAlias;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::Path;
-use std::path::PathBuf;
+use std::time::Duration;
 use std::time::SystemTimeError;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
-use sam_core::engines::SamHistory;
+use crate::associative_state::AssociativeStateWithTTL;
+use crate::associative_state::ErrorAssociativeState;
 
 pub trait VarsCache {
     fn put(&self, command: &dyn AsRef<str>, output: &dyn AsRef<str>) -> Result<(), CacheError>;
     fn get(&self, command: &dyn AsRef<str>) -> Result<Option<String>, CacheError>;
+}
+
+#[derive(Debug)]
+pub struct RustBreakCache {
+    state: AssociativeStateWithTTL<CacheEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CacheEntry {
+    pub command: String,
+    pub output: String,
+}
+
+impl RustBreakCache {
+    pub fn with_ttl(p: impl AsRef<Path>, ttl: &Duration) -> Result<Self, CacheError> {
+        Ok(RustBreakCache {
+            state: AssociativeStateWithTTL::<CacheEntry>::with_ttl(p, ttl)?,
+        })
+    }
+
+    pub fn entries(&self) -> Result<impl Iterator<Item = CacheEntry>, CacheError> {
+        Ok(self.state.entries()?.map(|(_, v)| v))
+    }
+
+    pub fn clear_cache(&self) -> Result<(), CacheError> {
+        for (key, _) in self.state.entries()? {
+            self.state.delete(key)?;
+        }
+        Ok(())
+    }
+}
+
+impl VarsCache for RustBreakCache {
+    fn put(&self, command: &dyn AsRef<str>, output: &dyn AsRef<str>) -> Result<(), CacheError> {
+        let key = command.as_ref().to_string();
+        let entry = CacheEntry {
+            command: key.clone(),
+            output: output.as_ref().to_string(),
+        };
+        Ok(self.state.put(key, entry)?)
+    }
+
+    fn get(&self, command: &dyn AsRef<str>) -> Result<Option<String>, CacheError> {
+        let cache_key = command.as_ref();
+        Ok(self.state.get(cache_key)?.map(|v| v.output))
+    }
 }
 
 pub struct NoopVarsCache {}
@@ -29,182 +70,47 @@ impl VarsCache for NoopVarsCache {
     }
 }
 
-#[derive(Debug)]
-pub struct RocksDBCache {
-    path: PathBuf,
-    ttl: Option<Duration>,
-}
-
-impl RocksDBCache {
-    // TODO expose a version without the TTL
-    pub fn with_ttl(p: impl AsRef<Path>, ttl: &Duration) -> Self {
-        RocksDBCache {
-            path: p.as_ref().to_owned(),
-            ttl: Some(*ttl),
-        }
-    }
-
-    pub fn new(p: impl AsRef<Path>) -> Self {
-        RocksDBCache {
-            path: p.as_ref().to_owned(),
-            ttl: None,
-        }
-    }
-
-    pub fn open_cache(&self) -> Result<DB, CacheError> {
-        let mut options = rocksdb::Options::default();
-        options.create_if_missing(true);
-        if let Some(ttl) = self.ttl {
-            DB::open_with_ttl(&options, self.path.clone(), ttl)
-                .map_err(|e| CacheError::RocksDBOpenError(self.path.clone(), e))
-        } else {
-            DB::open(&options, self.path.clone())
-                .map_err(|e| CacheError::RocksDBOpenError(self.path.clone(), e))
-        }
-    }
-
-    pub fn invalidate_if_too_old(&self, c: Option<CacheEntry>) -> Option<CacheEntry> {
-        c.filter(|e| e.is_valid(self.ttl))
-    }
-
-    pub fn clear_cache(&self) -> Result<(), CacheError> {
-        let db = self.open_cache()?;
-        let keys = db.iterator(rocksdb::IteratorMode::Start);
-        let mut batch = WriteBatch::default();
-        for (key, _) in keys {
-            batch.delete(key);
-        }
-        let mut options = WriteOptions::default();
-        options.set_sync(true);
-
-        db.write_opt(batch, &options)
-            .map_err(CacheError::RocksDBError)
-    }
-
-    pub fn keys(&self) -> Result<Vec<String>, CacheError> {
-        let db = self.open_cache()?;
-        let keys = db.iterator(rocksdb::IteratorMode::Start);
-        Ok(keys
-            .into_iter()
-            .map(|(key, _)| String::from_utf8_lossy(key.as_ref()).to_string())
-            .collect())
-    }
-}
-
-impl VarsCache for RocksDBCache {
-    fn put(&self, command: &dyn AsRef<str>, output: &dyn AsRef<str>) -> Result<(), CacheError> {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH)?;
-
-        let v = CacheEntry {
-            output: output.as_ref().to_string(),
-            creation_date: now.as_secs(),
-        };
-
-        let bytes = bincode::serialize(&v)?;
-        let db = self.open_cache()?;
-
-        let mut options = WriteOptions::default();
-        options.set_sync(true);
-
-        db.put_opt(command.as_ref(), bytes, &options)
-            .map_err(CacheError::RocksDBError)
-    }
-
-    fn get(&self, command: &dyn AsRef<str>) -> Result<Option<String>, CacheError> {
-        self.open_cache()?
-            .get(command.as_ref())?
-            .as_deref()
-            .map(bincode::deserialize::<CacheEntry>)
-            .transpose()
-            .map_err(CacheError::CacheEntryDeserializationErr)
-            .map(|e| self.invalidate_if_too_old(e).map(|e| e.output))
-    }
-}
-
-impl SamHistory for RocksDBCache {
-    fn get_last_n(&self, n: usize) -> std::result::Result<Vec<ResolvedAlias>, ErrorSamEngine> {
-        let db = self
-            .open_cache()
-            .map_err(|err| ErrorSamEngine::HistoryNotAvailable(Box::new(err)))?;
-        let keys = db.iterator(rocksdb::IteratorMode::End);
-        Ok(keys
-            .into_iter()
-            .take(n)
-            .flat_map(|(_, value)| serde_yaml::from_slice(&value))
-            .collect())
-    }
-
-    fn put(&self, alias: ResolvedAlias) -> std::result::Result<(), ErrorSamEngine> {
-        let db = self
-            .open_cache()
-            .map_err(|err| ErrorSamEngine::HistoryNotAvailable(Box::new(err)))?;
-        let key = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|err| ErrorSamEngine::HistoryNotAvailable(Box::new(err)))?
-            .as_secs();
-        let bin_ts = key.to_le_bytes();
-        let alias_bytes = serde_yaml::to_vec(&alias)
-            .map_err(|err| ErrorSamEngine::HistoryNotAvailable(Box::new(err)))?;
-
-        let mut options = WriteOptions::default();
-        options.set_sync(true);
-        db.put_opt(bin_ts, alias_bytes, &options)
-            .map_err(|err| ErrorSamEngine::HistoryNotAvailable(Box::new(err)))
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CacheEntry {
-    creation_date: u64,
-    output: String,
-}
-
-impl CacheEntry {
-    pub fn is_valid(&self, ttl: Option<Duration>) -> bool {
-        if let Some(t) = ttl {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("can't get timestamp from OS")
-                .as_secs();
-            (now - t.as_secs()) < self.creation_date
-        } else {
-            true
-        }
-    }
-}
 #[derive(Debug, Error)]
 pub enum CacheError {
-    #[error("can't open rockdb at path {0} because\n-> {1}")]
-    RocksDBOpenError(PathBuf, rocksdb::Error),
-    #[error("can't interract with rocksdb because\n-> {0}")]
-    RocksDBError(#[from] rocksdb::Error),
-    #[error("can't serialize value for cache insertion because\n-> {0}")]
-    CacheEntrySerializationErr(#[from] bincode::Error),
-    #[error("can't deserialize value for cache insertion because\n-> {0}")]
-    CacheEntryDeserializationErr(bincode::Error),
+    #[error("can't interract with rustbreak because\n-> {0}")]
+    RustbreakError(#[from] rustbreak::RustbreakError),
     #[error("could not get a timestamp from the system because\n-> {0}")]
     CantGetTimeStamp(#[from] SystemTimeError),
+    #[error("could not interract with cache because\n-> {0}")]
+    ErrAssociativeState(#[from] ErrorAssociativeState),
 }
 
 #[cfg(test)]
 mod tests {
-    use super::RocksDBCache;
-    use crate::vars_cache::VarsCache;
-    use sam_utils::fsutils::TempDirectory;
+    use crate::vars_cache::{RustBreakCache, VarsCache};
+    use sam_utils::fsutils::TempFile;
     use std::time::Duration;
 
     #[test]
-    pub fn test_rocksdb_cache() {
-        let tmp_dir = TempDirectory::new().expect("can't create a temporary directory");
+    pub fn test_rustbreak_cache() {
+        let tmp_dir = TempFile::new().expect("can't create a temporary file");
         let ttl = Duration::from_secs(90);
-        let cache = RocksDBCache::with_ttl(&tmp_dir.path, &ttl);
+        let cache = RustBreakCache::with_ttl(&tmp_dir.path, &ttl).expect("Can't open cache");
         cache
             .put(&String::from("command"), &String::from("output"))
-            .expect("can't write in rocksdb cache");
-        let value = cache
+            .expect("can't write in rustbreak cache");
+
+        let cache2 = RustBreakCache::with_ttl(&tmp_dir.path, &ttl).expect("Can't open cache");
+        let value = cache2
             .get(&String::from("command"))
-            .expect("can't read from rocksdb cache")
-            .expect("can't retrieve the value from rocksdb cache");
+            .expect("can't read from rustbreak cache")
+            .expect("can't retrieve the value from rustbreak cache");
+        assert_eq!(value, "output");
+
+        let cache = RustBreakCache::with_ttl(&tmp_dir.path, &ttl).expect("Can't open cache");
+        cache
+            .put(&String::from("command2"), &String::from("output"))
+            .expect("can't write in rustbreak cache");
+
+        let value = cache2
+            .get(&String::from("command2"))
+            .expect("can't read from rustbreak cache")
+            .expect("can't retrieve the value from rustbreak cache");
         assert_eq!(value, "output");
     }
 }


### PR DESCRIPTION
rocksdb is swapped for a smaller and simpler library ( rustbreak ) to :

1. Simplify the code and have less edge cases to test.
2. Reduce compilation time on the CI.

In addition, the state management facilities where improved by adding to
abstractions :

1. SequentialState that allows to persistence sequences
2. AssociativeState that allows to persist key-value pairs

This AssociativeState will be reused to deliver #33, #37 and #40

closes #34
closes #35